### PR TITLE
Add optional '?' to follow the convention

### DIFF
--- a/docs/cljs.core_def.cljsdoc
+++ b/docs/cljs.core_def.cljsdoc
@@ -6,15 +6,15 @@ special form
 
 ===== Signature
 [symbol]
-[symbol init]
-[symbol doc-string init]
+[symbol init?]
+[symbol doc-string? init?]
 
 ===== Description
 
 Creates a global variable with the name of `symbol` and a namespace of the
 current namespace.
 
-If `init` is supplied, it is evaluated and the result is assigned to `symbol`.
+If `init` is supplied, it is evaluated and the result is assigned to `symbol`, otherwise `symbol` is `nil`.
 
 `doc-string` is an optional documentation string.
 


### PR DESCRIPTION
Seems like there is a convention for optional arguments, at least in the `defn` they are appended with '?'. I also added one sentence about 'init' being 'nil' if not supplied.